### PR TITLE
Make use of fs.unlink() instead of node-tmp remove callback

### DIFF
--- a/tests/cache.spec.coffee
+++ b/tests/cache.spec.coffee
@@ -140,9 +140,9 @@ describe 'Cache:', ->
 				@cacheGetImagePathStub = m.sinon.stub(cache, 'getImagePath')
 				@cacheGetImagePathStub.returns(Promise.resolve(@image.name))
 
-			afterEach ->
+			afterEach (done) ->
 				@cacheGetImagePathStub.restore()
-				@image.removeCallback()
+				fs.unlink(@image.name, done)
 
 			it 'should return a stream to the image', (done) ->
 				cache.getImage('lorem-ipsum').then (stream) ->
@@ -169,9 +169,9 @@ describe 'Cache:', ->
 				@cacheGetImagePathStub = m.sinon.stub(cache, 'getImagePath')
 				@cacheGetImagePathStub.returns(Promise.resolve(@image.name))
 
-			afterEach ->
+			afterEach (done) ->
 				@cacheGetImagePathStub.restore()
-				@image.removeCallback()
+				fs.unlink(@image.name, done)
 
 			it 'should return a writable stream', (done) ->
 				cache.getImageWritableStream('raspberry-pi').then (stream) ->


### PR DESCRIPTION
For some reason, using `node-tmp` remove callbacks threw an error in
NodeJS v0.10 on Windows 7.

See: https://github.com/raszi/node-tmp/issues/58.