### PR TITLE
Fix issue when piping the same stream to both the cache and the client

### DIFF
--- a/build/manager.js
+++ b/build/manager.js
@@ -26,7 +26,9 @@ THE SOFTWARE.
 /**
  * @module manager
  */
-var cache, image;
+var cache, image, stream;
+
+stream = require('stream');
 
 cache = require('./cache');
 
@@ -55,9 +57,15 @@ exports.get = function(slug) {
       return cache.getImage(slug);
     }
     return image.download(slug).then(function(imageStream) {
+      var pass;
+      pass = new stream.PassThrough();
+      imageStream.pipe(pass);
+      imageStream.on('progress', function(state) {
+        return pass.emit('progress', state);
+      });
       return cache.getImageWritableStream(slug).then(function(cacheStream) {
-        imageStream.pipe(cacheStream);
-        return imageStream;
+        pass.pipe(cacheStream);
+        return pass;
       });
     });
   });


### PR DESCRIPTION
Piping the same `ReadableStream` to both the cache and the client didn't
work in some cases, resulting in the following error being thrown:

	Error: You cannot pipe after data has been emitted from the response.

The solution was to immediately pipe the download stream to a
`PassThrough` stream. Then, we were able to pipe the `PassThrough`
stream to multiple `WritableStreams` without any issue.

The solution was found in the following StackOverflow answer:

http://stackoverflow.com/questions/19553837/node-js-piping-the-same-stream-into-multiple-writable-targets