### PR TITLE
Fix unit tests failing because of unmocked /whoami endpoint

### DIFF
--- a/tests/fixtures/tokens.json
+++ b/tests/fixtures/tokens.json
@@ -1,0 +1,19 @@
+{
+	"johndoe": {
+		"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImpvaG5kb2UxIiwiZW1haWwiOiJqb2huZG9lQGpvaG5kb2UuY29tIiwiZ2l0bGFiX2lkIjoxMzI1LCJzb2NpYWxfc2VydmljZV9hY2NvdW50IjpudWxsLCJoYXNQYXNzd29yZFNldCI6dHJ1ZSwibmVlZHNQYXNzd29yZFJlc2V0IjpmYWxzZSwicHVibGljX2tleSI6ZmFsc2UsImZlYXR1cmVzIjpbXSwiaWQiOjEzNDQsImludGVyY29tVXNlckhhc2giOiJlMDM3NzhkZDI5ZTE1NzQ0NWYyNzJhY2M5MjExNzBjZjI4MTBiNjJmNTAyNjQ1MjY1Y2MzNDlkNmRlZGEzNTI0IiwicGVybWlzc2lvbnMiOltdLCJpYXQiOjE0MjY3ODMzMTJ9.v5bmh9HwyUZu8zhh1rA79mTL-1jzDOO8eUr_lVaBwhg",
+		"data": {
+			"id": 1344,
+			"email": "johndoe@johndoe.com",
+			"username": "johndoe1",
+			"features": [],
+			"gitlab_id": 1325,
+			"hasPasswordSet": true,
+			"iat": 1426783312,
+			"intercomUserHash": "e03778dd29e157445f272acc921170cf2810b62f502645265cc349d6deda3524",
+			"needsPasswordReset": false,
+			"permissions": [],
+			"public_key": false,
+			"social_service_account": null
+		}
+	}
+}

--- a/tests/image.spec.coffee
+++ b/tests/image.spec.coffee
@@ -2,6 +2,7 @@ m = require('mochainon')
 Promise = require('bluebird')
 nock = require('nock')
 resin = require('resin-sdk')
+fixtures = require('./fixtures/tokens.json')
 image = require('../lib/image')
 
 describe 'Image:', ->
@@ -61,39 +62,50 @@ describe 'Image:', ->
 
 			describe 'given the desired device type is valid', ->
 
-				describe 'given a valid download endpoint', ->
+				describe 'given an always valid whoami endpoint', ->
 
 					beforeEach (done) ->
 						resin.settings.get('remoteUrl').then (remoteUrl) ->
-							nock(remoteUrl).get('/download?network=ethernet&appId=1')
-								.reply(200, 'Lorem ipsum dolor sit amet')
+							nock(remoteUrl).get('/whoami')
+								.reply(200, fixtures.johndoe.token)
 							done()
 
 					afterEach ->
 						nock.cleanAll()
 
-					it 'should stream the download', (done) ->
-						image.download('raspberry-pi').then (stream) ->
-							result = ''
+					describe 'given a valid download endpoint', ->
 
-							stream.on 'data', (chunk) ->
-								result += chunk
-
-							stream.on 'end', ->
-								m.chai.expect(result).to.equal('Lorem ipsum dolor sit amet')
+						beforeEach (done) ->
+							resin.settings.get('remoteUrl').then (remoteUrl) ->
+								nock(remoteUrl).get('/download?network=ethernet&appId=1')
+									.reply(200, 'Lorem ipsum dolor sit amet')
 								done()
 
-				describe 'given an invalid download endpoint', ->
+						afterEach ->
+							nock.cleanAll()
 
-					beforeEach (done) ->
-						resin.settings.get('remoteUrl').then (remoteUrl) ->
-							nock(remoteUrl).get('/download?network=ethernet&appId=1')
-								.reply(400, 'Invalid application id')
-							done()
+						it 'should stream the download', (done) ->
+							image.download('raspberry-pi').then (stream) ->
+								result = ''
 
-					afterEach ->
-						nock.cleanAll()
+								stream.on 'data', (chunk) ->
+									result += chunk
 
-					it 'should be rejected with an error message', ->
-						promise = image.download('raspberry-pi')
-						m.chai.expect(promise).to.be.rejectedWith('Invalid application id')
+								stream.on 'end', ->
+									m.chai.expect(result).to.equal('Lorem ipsum dolor sit amet')
+									done()
+
+					describe 'given an invalid download endpoint', ->
+
+						beforeEach (done) ->
+							resin.settings.get('remoteUrl').then (remoteUrl) ->
+								nock(remoteUrl).get('/download?network=ethernet&appId=1')
+									.reply(400, 'Invalid application id')
+								done()
+
+						afterEach ->
+							nock.cleanAll()
+
+						it 'should be rejected with an error message', ->
+							promise = image.download('raspberry-pi')
+							m.chai.expect(promise).to.be.rejectedWith('Invalid application id')


### PR DESCRIPTION
New Resin Request versions checl the validity of the token and attempt
to refresh it by triggering requests to `GET /whoami`, which needs to be
explicitly mocked on unit tests.