### PR TITLE
Correctly mock os parameters for different device types

### DIFF
--- a/build/image.js
+++ b/build/image.js
@@ -49,17 +49,26 @@ resin = require('resin-sdk');
 
 exports.getOSParameters = function(slug) {
   return resin.models.application.getAll().then(function(applications) {
-    var application;
+    var application, result;
     application = _.find(applications, {
       device_type: slug
     });
     if (application == null) {
       throw new Error("Unknown device type: " + slug);
     }
-    return {
+    result = {
       network: 'ethernet',
       appId: application.id
     };
+    if (slug === 'parallella') {
+      result.processorType = 'Z7010';
+      result.coprocessorCore = '16';
+    } else if (slug === 'intel-edison') {
+      result.network = 'wifi';
+      result.wifiSsid = 'ssid';
+      result.wifiKey = 'key';
+    }
+    return result;
   });
 };
 

--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -49,10 +49,19 @@ exports.getOSParameters = (slug) ->
 		if not application?
 			throw new Error("Unknown device type: #{slug}")
 
-		return {
+		result =
 			network: 'ethernet'
 			appId: application.id
-		}
+
+		if slug is 'parallella'
+			result.processorType = 'Z7010'
+			result.coprocessorCore = '16'
+		else if slug is 'intel-edison'
+			result.network = 'wifi'
+			result.wifiSsid = 'ssid'
+			result.wifiKey = 'key'
+
+		return result
 
 ###*
 # @summary Download a device image

--- a/tests/image.spec.coffee
+++ b/tests/image.spec.coffee
@@ -15,6 +15,7 @@ describe 'Image:', ->
 				@resinApplicationGetAllStub.returns Promise.resolve [
 					{ id: 1, device_type: 'raspberry-pi' }
 					{ id: 2, device_type: 'intel-edison' }
+					{ id: 3, device_type: 'parallella' }
 				]
 
 			afterEach ->
@@ -34,11 +35,48 @@ describe 'Image:', ->
 			describe 'given it does not have an app of the required type', ->
 
 				beforeEach ->
-					@deviceType = 'parallela'
+					@deviceType = 'foo'
 
 				it 'should be rejected with an error message', ->
 					promise = image.getOSParameters(@deviceType)
 					m.chai.expect(promise).to.be.rejectedWith("Unknown device type: #{@deviceType}")
+
+			describe 'given a raspberry pi device type', ->
+
+				beforeEach ->
+					@deviceType = 'raspberry-pi'
+
+				it 'should contain all required parameters', ->
+					promise = image.getOSParameters(@deviceType)
+					m.chai.expect(promise).to.become
+						appId: 1
+						network: 'ethernet'
+
+			describe 'given an edison device type', ->
+
+				beforeEach ->
+					@deviceType = 'intel-edison'
+
+				it 'should contain all required parameters', ->
+					promise = image.getOSParameters(@deviceType)
+					m.chai.expect(promise).to.become
+						appId: 2
+						network: 'wifi'
+						wifiSsid: 'ssid'
+						wifiKey: 'key'
+
+			describe 'given a parallella device type', ->
+
+				beforeEach ->
+					@deviceType = 'parallella'
+
+				it 'should contain all required parameters', ->
+					promise = image.getOSParameters(@deviceType)
+					m.chai.expect(promise).to.become
+						appId: 3
+						network: 'ethernet'
+						processorType: 'Z7010'
+						coprocessorCore: '16'
 
 	describe '.download()', ->
 


### PR DESCRIPTION
- Include `processorType` and `coprocessorCore` for Parallella.

- Force `wifi` for Intel Edison.

In the short future, this function will be refactored to read options
from the manifests and automatically pick the required mock options.