### PR TITLE
Pipe stream to a PassThrough before returning to client

### DIFF
--- a/build/manager.js
+++ b/build/manager.js
@@ -64,8 +64,14 @@ exports.get = function(slug) {
         return pass.emit('progress', state);
       });
       return cache.getImageWritableStream(slug).then(function(cacheStream) {
+        var pass2;
         pass.pipe(cacheStream);
-        return pass;
+        pass2 = new stream.PassThrough();
+        pass.on('progress', function(state) {
+          return pass2.emit('progress', state);
+        });
+        pass.pipe(pass2);
+        return pass2;
       });
     });
   });

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -62,7 +62,16 @@ exports.get = (slug) ->
 			cache.getImageWritableStream(slug).then (cacheStream) ->
 				pass.pipe(cacheStream)
 
-				return pass
+				# If we return `pass` directly, the client will not be able
+				# to read all data from it after a delay, since it will be
+				# instantly piped to `cacheStream`.
+				# The solution is to create yet another PassThrough stream,
+				# pipe to it and return the new stream instead.
+				pass2 = new stream.PassThrough()
+				pass.on 'progress', (state) ->
+					pass2.emit('progress', state)
+				pass.pipe(pass2)
+				return pass2
 
 ###*
 # @summary Clean the saved images cache

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bluebird": "^2.9.30",
     "lodash": "^3.10.0",
     "mkdirp": "^0.5.1",
-    "resin-sdk": "~2.4.1",
+    "resin-sdk": "~2.5.0",
     "rimraf": "^2.4.1"
   }
 }

--- a/tests/manager.spec.coffee
+++ b/tests/manager.spec.coffee
@@ -1,5 +1,7 @@
 m = require('mochainon')
+_ = require('lodash')
 tmp = require('tmp')
+PassThrough = require('stream').PassThrough
 Promise = require('bluebird')
 fs = Promise.promisifyAll(require('fs'))
 stringToStream = require('string-to-stream')
@@ -75,3 +77,19 @@ describe 'Manager:', ->
 								fs.readFileAsync(@image.name, encoding: 'utf8').then (contents) ->
 									m.chai.expect(contents).to.equal('Download image')
 									done()
+
+					it 'should be able to read from the stream after a slight delay', (done) ->
+						manager.get('raspberry-pi').then (stream) ->
+							Promise.delay(200).return(stream)
+						.then (stream) ->
+							pass = new PassThrough()
+							stream.pipe(pass)
+
+							result = ''
+
+							pass.on 'data', (chunk) ->
+								result += chunk
+
+							pass.on 'end', ->
+								m.chai.expect(result).to.equal('Download image')
+								done()


### PR DESCRIPTION
If the client tries to read data from the returned stream after a
slight delay, nothing will be read, since data will be already piped to
the cache location.

The solution is to instantly pipe to a PassThrough stream at the same
time that piping to the cache location and return this new stream
instead.