### PR TITLE
Preserve download stream length property, if any

### DIFF
--- a/build/manager.js
+++ b/build/manager.js
@@ -65,6 +65,7 @@ exports.get = function(slug) {
       var pass2;
       pass.pipe(cacheStream);
       pass2 = new stream.PassThrough();
+      pass2.length = imageStream.length;
       imageStream.on('progress', function(state) {
         return pass2.emit('progress', state);
       });

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -66,6 +66,7 @@ exports.get = (slug) ->
 			# The solution is to create yet another PassThrough stream,
 			# pipe to it and return the new stream instead.
 			pass2 = new stream.PassThrough()
+			pass2.length = imageStream.length
 			imageStream.on 'progress', (state) ->
 				pass2.emit('progress', state)
 			return pass.pipe(pass2)

--- a/tests/manager.spec.coffee
+++ b/tests/manager.spec.coffee
@@ -93,3 +93,20 @@ describe 'Manager:', ->
 							pass.on 'end', ->
 								m.chai.expect(result).to.equal('Download image')
 								done()
+
+				describe 'given a stream with a length property', ->
+
+					beforeEach ->
+						@imageDownloadStub = m.sinon.stub(image, 'download')
+						message = 'Lorem ipsum dolor sit amet'
+						stream = stringToStream(message)
+						stream.length = message.length
+						@imageDownloadStub.returns(Promise.resolve(stream))
+
+					afterEach ->
+						@imageDownloadStub.restore()
+
+					it 'should preserve the property', (done) ->
+						manager.get('raspberry-pi').then (stream) ->
+							m.chai.expect(stream.length).to.equal(26)
+						.nodeify(done)


### PR DESCRIPTION
`resin-request` assigns a custom `length` property to the image stream
if a `Content-Length` header is present.

Given the PassThrough workarounds, where we pipe the original stream
twice, this information was being lost.