### PR TITLE
Preserve stream mime custom property

### DIFF
--- a/build/manager.js
+++ b/build/manager.js
@@ -66,6 +66,7 @@ exports.get = function(slug) {
       pass.pipe(cacheStream);
       pass2 = new stream.PassThrough();
       pass2.length = imageStream.length;
+      pass2.mime = imageStream.mime;
       imageStream.on('progress', function(state) {
         return pass2.emit('progress', state);
       });

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -67,6 +67,7 @@ exports.get = (slug) ->
 			# pipe to it and return the new stream instead.
 			pass2 = new stream.PassThrough()
 			pass2.length = imageStream.length
+			pass2.mime = imageStream.mime
 			imageStream.on 'progress', (state) ->
 				pass2.emit('progress', state)
 			return pass.pipe(pass2)

--- a/tests/manager.spec.coffee
+++ b/tests/manager.spec.coffee
@@ -110,3 +110,20 @@ describe 'Manager:', ->
 						manager.get('raspberry-pi').then (stream) ->
 							m.chai.expect(stream.length).to.equal(26)
 						.nodeify(done)
+
+				describe 'given a stream with a mime property', ->
+
+					beforeEach ->
+						@imageDownloadStub = m.sinon.stub(image, 'download')
+						message = 'Lorem ipsum dolor sit amet'
+						stream = stringToStream(message)
+						stream.mime = 'application/zip'
+						@imageDownloadStub.returns(Promise.resolve(stream))
+
+					afterEach ->
+						@imageDownloadStub.restore()
+
+					it 'should preserve the property', (done) ->
+						manager.get('raspberry-pi').then (stream) ->
+							m.chai.expect(stream.mime).to.equal('application/zip')
+						.nodeify(done)


### PR DESCRIPTION
Resin Request saves the value of the `Content-Type` HTTP header as a
custom `mime` property.

Given we pipe the download to a PassThrough stream and resolve that
instead in Resin Image Manager, the property value is being lost.