### PR TITLE
Preserve mime custom property when fetching from the cache

### DIFF
--- a/build/cache.js
+++ b/build/cache.js
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var Promise, fs, mkdirp, path, resin, rimraf, utils;
+var Promise, fs, mime, mkdirp, path, resin, rimraf, utils;
 
 Promise = require('bluebird');
 
@@ -31,6 +31,8 @@ fs = Promise.promisifyAll(require('fs'));
 mkdirp = Promise.promisify(require('mkdirp'));
 
 rimraf = Promise.promisify(require('rimraf'));
+
+mime = require('mime');
 
 resin = require('resin-sdk');
 
@@ -114,6 +116,7 @@ exports.getImage = function(slug) {
       var stream;
       stream = fs.createReadStream(imagePath);
       stream.length = size;
+      stream.mime = mime.lookup(imagePath);
       return stream;
     });
   });

--- a/lib/cache.coffee
+++ b/lib/cache.coffee
@@ -26,6 +26,7 @@ Promise = require('bluebird')
 fs = Promise.promisifyAll(require('fs'))
 mkdirp = Promise.promisify(require('mkdirp'))
 rimraf = Promise.promisify(require('rimraf'))
+mime = require('mime')
 resin = require('resin-sdk')
 path = require('path')
 utils = require('./utils')
@@ -98,6 +99,7 @@ exports.getImage = (slug) ->
 		utils.getFileSize(imagePath).then (size) ->
 			stream = fs.createReadStream(imagePath)
 			stream.length = size
+			stream.mime = mime.lookup(imagePath)
 			return stream
 
 ###*

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "bluebird": "^2.9.30",
     "lodash": "^3.10.0",
+    "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "resin-sdk": "~2.6.1",
     "rimraf": "^2.4.1",

--- a/tests/cache.spec.coffee
+++ b/tests/cache.spec.coffee
@@ -165,6 +165,11 @@ describe 'Cache:', ->
 					m.chai.expect(stream.length).to.equal(26)
 					done()
 
+			it 'should contain a mime property', (done) ->
+				cache.getImage('lorem-ipsum').then (stream) ->
+					m.chai.expect(stream.mime).to.equal('application/octet-stream')
+					done()
+
 	describe '.getImageWritableStream()', ->
 
 		describe 'given an valid image path', ->


### PR DESCRIPTION
The custom `mime` property is set by Resin Request based on the
`Content-Type` HTTP header. Once the image is saved in the cache,
reading from there will result in the `mime` information being lost.