### PR TITLE
Fix image not being able to be fetched from the cache

### DIFF
--- a/build/manager.js
+++ b/build/manager.js
@@ -62,21 +62,21 @@ exports.get = function(slug) {
     if (isFresh) {
       return cache.getImage(slug);
     }
-    return image.download(slug);
-  }).then(function(imageStream) {
-    var pass;
-    pass = new stream.PassThrough();
-    imageStream.pipe(pass);
-    return cache.getImageWritableStream(slug).then(function(cacheStream) {
-      var pass2;
-      pass.pipe(cacheStream);
-      pass2 = new stream.PassThrough();
-      pass2.length = imageStream.length;
-      pass2.mime = imageStream.mime;
-      imageStream.on('progress', function(state) {
-        return pass2.emit('progress', state);
+    return image.download(slug).then(function(imageStream) {
+      var pass;
+      pass = new stream.PassThrough();
+      imageStream.pipe(pass);
+      return cache.getImageWritableStream(slug).then(function(cacheStream) {
+        var pass2;
+        pass.pipe(cacheStream);
+        pass2 = new stream.PassThrough();
+        pass2.length = imageStream.length;
+        pass2.mime = imageStream.mime;
+        imageStream.on('progress', function(state) {
+          return pass2.emit('progress', state);
+        });
+        return pass.pipe(pass2);
       });
-      return pass.pipe(pass2);
     });
   });
 };

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -51,29 +51,28 @@ utils = require('./utils')
 exports.get = (slug) ->
 	cache.isImageFresh(slug).then (isFresh) ->
 		return cache.getImage(slug) if isFresh
-		return image.download(slug)
-	.then (imageStream) ->
+		return image.download(slug).then (imageStream) ->
 
-		# Piping to a PassThrough stream is needed to be able
-		# to then pipe the stream to multiple destinations.
-		pass = new stream.PassThrough()
-		imageStream.pipe(pass)
+			# Piping to a PassThrough stream is needed to be able
+			# to then pipe the stream to multiple destinations.
+			pass = new stream.PassThrough()
+			imageStream.pipe(pass)
 
-		# Save a copy of the image in the cache
-		cache.getImageWritableStream(slug).then (cacheStream) ->
-			pass.pipe(cacheStream)
+			# Save a copy of the image in the cache
+			cache.getImageWritableStream(slug).then (cacheStream) ->
+				pass.pipe(cacheStream)
 
-			# If we return `pass` directly, the client will not be able
-			# to read all data from it after a delay, since it will be
-			# instantly piped to `cacheStream`.
-			# The solution is to create yet another PassThrough stream,
-			# pipe to it and return the new stream instead.
-			pass2 = new stream.PassThrough()
-			pass2.length = imageStream.length
-			pass2.mime = imageStream.mime
-			imageStream.on 'progress', (state) ->
-				pass2.emit('progress', state)
-			return pass.pipe(pass2)
+				# If we return `pass` directly, the client will not be able
+				# to read all data from it after a delay, since it will be
+				# instantly piped to `cacheStream`.
+				# The solution is to create yet another PassThrough stream,
+				# pipe to it and return the new stream instead.
+				pass2 = new stream.PassThrough()
+				pass2.length = imageStream.length
+				pass2.mime = imageStream.mime
+				imageStream.on 'progress', (state) ->
+					pass2.emit('progress', state)
+				return pass.pipe(pass2)
 
 ###*
 # @summary Clean the saved images cache


### PR DESCRIPTION
If the image was fetched from the cache, we we're still attempted to
write to the cache, which resulted in the image data being corrupted
since we cannot pipe the same stream to the same location.