### PR TITLE
Move to preconfigured Resin-SDK (and drop Node <4 from the tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+  - "node"
+  - "6"
+  - "4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Moved to [resin-sdk-preconfigured](https://github.com/resin-io-modules/resin-sdk-preconfigured)
+
 ## [4.0.1] - 2016-06-21
 
 ### Changed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,8 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.11
-    - nodejs_version: 0.12
+    - nodejs_version: '6'
+    - nodejs_version: '4'
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/build/cache.js
+++ b/build/cache.js
@@ -26,7 +26,7 @@ rimraf = Promise.promisify(require('rimraf'));
 
 mime = require('mime');
 
-resin = require('resin-sdk');
+resin = require('resin-sdk-preconfigured');
 
 path = require('path');
 

--- a/build/manager.js
+++ b/build/manager.js
@@ -24,7 +24,7 @@ stream = require('stream');
 
 fs = require('fs');
 
-resin = require('resin-sdk');
+resin = require('resin-sdk-preconfigured');
 
 cache = require('./cache');
 

--- a/lib/cache.coffee
+++ b/lib/cache.coffee
@@ -19,7 +19,7 @@ fs = Promise.promisifyAll(require('fs'))
 mkdirp = Promise.promisify(require('mkdirp'))
 rimraf = Promise.promisify(require('rimraf'))
 mime = require('mime')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 path = require('path')
 utils = require('./utils')
 

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -20,7 +20,7 @@ limitations under the License.
 
 stream = require('stream')
 fs = require('fs')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 cache = require('./cache')
 utils = require('./utils')
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^3.10.0",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
-    "resin-sdk": "^5.3.3",
+    "resin-sdk-preconfigured": "^0.1.0",
     "rimraf": "^2.4.1"
   }
 }

--- a/tests/cache.spec.coffee
+++ b/tests/cache.spec.coffee
@@ -7,7 +7,7 @@ os = require('os')
 tmp = require('tmp')
 mockFs = require('mock-fs')
 stringToStream = require('string-to-stream')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 cache = require('../lib/cache')
 utils = require('../lib/utils')
 

--- a/tests/manager.spec.coffee
+++ b/tests/manager.spec.coffee
@@ -1,5 +1,5 @@
 m = require('mochainon')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 path = require('path')
 tmp = require('tmp')
 PassThrough = require('stream').PassThrough


### PR DESCRIPTION
This one is a little more interesting than the others, as it stops running the tests with Node versions before Node 4. This is primarily because 0.10 was causing some bizarre errors in the tests (saying it couldn't require 'bluebird', despite depending on it, and having the test suite stall for 10 minutes with no output), and we've already dropped these versions from testing in the new Resin-SDK version anyway.

I'm putting that bit in here partly also for debate on whether we're happy to start doing this everywhere. I don't think we need to run around actively making sure this is the case in every repo or anything, but it'd be good to agree that it's our standard level for our tools (or not!) and to think about incrementally update codebases to this as we see them if so.